### PR TITLE
retirer une erreur de frappe

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,6 @@
             <artifactId>picocli</artifactId>
             <version>4.7.5</version>
         </dependency>
-    </dependencies>git 
+    </dependencies>
 
 </project>


### PR DESCRIPTION
un "git" s'était glissé dans le code